### PR TITLE
Use Maia via Lc0 for analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ install(TARGETS ChessGUI
 )
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/assets DESTINATION .)
-install(FILES ${CMAKE_SOURCE_DIR}/stockfish.exe DESTINATION .)
+install(FILES ${CMAKE_SOURCE_DIR}/lc0.exe DESTINATION .)
 
 # Install OpenCV DLL (adjust filename if needed)
 install(FILES "C:/opencv/build/x64/vc16/bin/opencv_world4110.dll" DESTINATION .)
@@ -116,7 +116,7 @@ install(DIRECTORY "${CMAKE_SOURCE_DIR}/external/python/"
 install(FILES ${CPACK_INSTALL_SYSTEM_RUNTIME_LIBS}
         DESTINATION python)
 
-file(COPY ${CMAKE_SOURCE_DIR}/stockfish.exe DESTINATION ${CMAKE_BINARY_DIR})
+file(COPY ${CMAKE_SOURCE_DIR}/lc0.exe DESTINATION ${CMAKE_BINARY_DIR})
 
 # Copy assets folder to build directory
 add_custom_command(

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <h1 align="center">FENgineLive</h1>
-<p align="center"><em>Real-time chess-board recognition · Stockfish analysis · On-screen & in-game assistance</em></p>
+<p align="center"><em>Real-time chess-board recognition · Maia (Lc0) analysis · On-screen & in-game assistance</em></p>
 
 ---
 
@@ -28,14 +28,14 @@
 ---
 
 ## Overview
-**FENgineLive** is a hybrid **Qt (C++17)** + **Python** application that captures periodic screenshots of any chess interface, converts the current position to **FEN** with a custom [*Convolutional Chess Network*](https://github.com/hammersurf221/FENgine) (CCN), and feeds it to **Stockfish**.
+**FENgineLive** is a hybrid **Qt (C++17)** + **Python** application that captures periodic screenshots of any chess interface, converts the current position to **FEN** with a custom [*Convolutional Chess Network*](https://github.com/hammersurf221/FENgine) (CCN), and feeds it to **Maia** using the **Lc0** backend.
 
 The GUI then:
 
 * Renders the position in its own board widget  
-* Draws an arrow for Stockfish’s best move  
-* Shows evaluation, move history, and the raw FEN  
-* Offers **Stealth Mode** that limits Stockfish strength and chooses moves with human-like randomness (optional)
+* Draws an arrow for Maia’s best move
+* Shows evaluation, move history, and the raw FEN
+* Offers **Stealth Mode** that limits search depth and chooses moves with human-like randomness (optional)
 * Can **Auto-Move** the chosen move directly on the board (optional)  
 
 Use it for real-time tactics training, stream overlays, or hands-free auto-playing—completely client-side.
@@ -47,8 +47,8 @@ Use it for real-time tactics training, stream overlays, or hands-free auto-playi
 | Category | Highlights |
 |----------|------------|
 | **Real-time Vision** | CCN predicts an 8 × 8 grid of piece classes from 256 × 256 RGB crops. Currently only works with specific themes. You can train your own weights at  https://github.com/hammersurf221/FENgine|
-| **Stockfish Integration** | UCI handshake, multi-PV, centipawn / mate parsing, repetition avoidance. |
-| **Stealth Mode** | Limits Stockfish to 2300 Elo, then picks from the top lines via softmax with human delays. |
+| **Maia/Lc0 Integration** | UCI handshake with backend options and evaluation parsing. |
+| **Stealth Mode** | Uses shallow depth (e.g., 6 plies) then picks from the top line via softmax with human delays. |
 | **Auto-Move** | Uses `pyautogui` to click the recommended move on your chess site—works with Lichess/Chess.com & most GUI boards. Toggle on/off any time. |
 | **Telemetry Dashboard** | Records stealth moves to `telemetry_log.json` and shows real-time stats in a dockable widget. |
 | **Region Auto-Detect + Manual Fallback** | Detects the chessboard rectangle via OpenCV; cancel to draw region manually. |
@@ -63,7 +63,7 @@ Use it for real-time tactics training, stream overlays, or hands-free auto-playi
 
 | Component | Minimum Version |
 |-----------|-----------------|
-| **Stockfish** | 15 + |
+| **Lc0** | 0.29 + |
 | **Qt** (Widgets, GUI, Core) | 5.15 or 6.x |
 | **OpenCV** | 4.x |
 | **Python** | 3.8 + |
@@ -94,7 +94,7 @@ cmake --build build --parallel
 # 3. Install Python deps
 python -m pip install -r python/requirements.txt
 
-# 4. Copy or symlink your Stockfish executable,
+# 4. Copy or symlink your Lc0 executable and Maia network,
 #    then launch the GUI:
 ./build/FENgineLive            # Linux/macOS
 build\Release\FENgineLive.exe  # Windows
@@ -116,7 +116,7 @@ build\Release\FENgineLive.exe  # Windows
 1. **Open a chess site or GUI** and start a game.  
 2. Launch **FENgineLive** – a translucent overlay appears.  
 3. Press **`Ctrl + A`** (default) to start/stop analysis.  
-4. The app captures a screenshot every *N ms* (set in **Settings → Analysis Interval**), predicts the FEN, and queries Stockfish.  
+4. The app captures a screenshot every *N ms* (set in **Settings → Analysis Interval**), predicts the FEN, and queries Maia via Lc0.
 5. Watch the best-move arrow, evaluation bar, and PGN history update in real-time.  
 6. Toggle **Stealth Mode** (*`Ctrl + S`*) to enable the humanized move picker.
 7. Toggle **Auto-Move** (*`Ctrl + M`*) if you’d like the app to physically play the move on your board.  
@@ -132,7 +132,7 @@ build\Release\FENgineLive.exe  # Windows
 | **Predicted FEN is incorrect** | You may be using a model weight trained on a different theme than the one you are currently using. Simply use a basic chess.com board and the "Icy Sea" theme on Chess.com. |
 | **Board not detected or wrong size** | For now, manually set your board region. Board autodetection is in the process of being optimized. |
 | **Auto-Move clicks in the wrong place** | Ensure your browser window is the same scale when you captured the region; re-run **Capture Region**. |
-| **No Stockfish output** | Check **Settings → Engine Path** and make sure you are using the right path to **stockfish.exe**. |
+| **No engine output** | Check **Settings → Engine Path** and make sure you are using the correct path to **lc0.exe** and that the Maia network file exists. |
 | **Hotkeys do nothing on macOS/Linux** | Global hotkeys are Windows-only for now; use menu toggles instead. |
 
 A fuller FAQ lives in **docs/TROUBLESHOOTING.md** -> ***STILL BEING MADE***.
@@ -150,7 +150,7 @@ Currently placeholders.
 
 ## Learning Resources
 * **CCN architecture** – see <https://github.com/hammersurf221/FENgine> for model code and residual enhancements.    
-* **Stockfish UCI protocol** – <https://github.com/official-stockfish/Stockfish/wiki/UCI-Protocol>  
+* **Lc0 UCI options** – <https://github.com/LeelaChessZero/lc0/wiki/Parameters>
 * **Qt Widgets** – <https://doc.qt.io/>  
 * **OpenCV 4.x tutorials** – <https://docs.opencv.org/>  
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -47,22 +47,22 @@ private:
     QTimer* screenshotTimer;
     bool analysisRunning = false;
     QProcess* pythonProcess = nullptr;
-    QProcess* stockfishProcess = nullptr;
+    QProcess* engineProcess = nullptr;
     QString lastFen;
     int analysisInterval = 1000;  // milliseconds
-    int stockfishDepth = 15;
+    int engineDepth = 15;
     int autoMoveDelayMs = 0;
     bool autoMoveWhenReady = false;
     bool useAutoBoardDetectionSetting = true;
     bool forceManualRegionSetting = false;
-    QString stockfishPath;
+    QString enginePath;
     QString fenModelPath;
     QString getMyColor() const;
     void captureScreenshot();
     void runFenPrediction(const QString& imagePath);
     QProcess* fenServer = nullptr;
     QString myColor = "w";
-    void startStockfish();
+    void startEngine();
     void evaluatePosition(const QString& fen);
     QRect autoDetectedRegion;
     QDialog* autoOverlay = nullptr;
@@ -118,7 +118,7 @@ private:
     bool lastEvalValid = false;
     int pendingEvalLine = -1;
 
-    bool restartStockfishOnCrash = true;
+    bool restartEngineOnCrash = true;
     bool restartFenServerOnCrash = true;
 
     void setRandomSeed(quint32 seed) { randomSeed = seed; randomGenerator.seed(seed); }

--- a/settingsdialog.cpp
+++ b/settingsdialog.cpp
@@ -26,7 +26,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
 
     depthSpinBox = new QSpinBox(coreTab);
     depthSpinBox->setRange(1, 30);
-    coreLayout->addRow(tr("Stockfish Depth"), depthSpinBox);
+    coreLayout->addRow(tr("Engine Depth"), depthSpinBox);
 
     stealthCheckBox = new QCheckBox(tr("Enable Stealth Mode"), coreTab);
     coreLayout->addRow(stealthCheckBox);
@@ -66,7 +66,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     stockfishLayout->addWidget(stockfishBrowseButton);
     QWidget *stockfishWidget = new QWidget(miscTab);
     stockfishWidget->setLayout(stockfishLayout);
-    miscLayout->addRow(tr("Path to Stockfish Executable"), stockfishWidget);
+    miscLayout->addRow(tr("Path to Engine Executable"), stockfishWidget);
 
     QHBoxLayout *fenLayout = new QHBoxLayout();
     fenModelPathEdit = new QLineEdit(miscTab);
@@ -122,7 +122,7 @@ void SettingsDialog::loadSettings()
     setAutoMoveDelay(settings.value("autoMoveDelay", 0).toInt());
 
 
-    QString defaultStockfish = QCoreApplication::applicationDirPath() + "/stockfish.exe";
+    QString defaultStockfish = QCoreApplication::applicationDirPath() + "/lc0.exe";
     QString defaultFenModel = QCoreApplication::applicationDirPath() + "/python/fen_tracker/ccn_model_default.pth";
 
     setStockfishPath(settings.value("stockfishPath", defaultStockfish).toString());
@@ -152,7 +152,7 @@ void SettingsDialog::accept()
 
 void SettingsDialog::browseStockfish()
 {
-    QString file = QFileDialog::getOpenFileName(this, tr("Select Stockfish Executable"));
+    QString file = QFileDialog::getOpenFileName(this, tr("Select Engine Executable"));
     if (!file.isEmpty())
         stockfishPathEdit->setText(file);
 }
@@ -173,7 +173,7 @@ void SettingsDialog::resetDefaults()
     setForceManualRegion(false);
     setAutoMoveWhenReady(false);
     setAutoMoveDelay(0);
-    setStockfishPath(QCoreApplication::applicationDirPath() + "/stockfish.exe");
+    setStockfishPath(QCoreApplication::applicationDirPath() + "/lc0.exe");
     setFenModelPath(QCoreApplication::applicationDirPath() + "/python/fen_tracker/ccn_model_default.pth");
     setDefaultPlayerColor("White");
 }


### PR DESCRIPTION
## Summary
- swap Stockfish engine integration for Maia running with the Lc0 backend
- configure UCI options for backend and network file
- change settings labels to reference the generic engine
- update build/install to copy `lc0.exe`
- document the change from Stockfish to Maia/Lc0 in the README

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_684bb6a1bf148326b5554cfa52951355