### PR TITLE
Improve stealth settings and runtime bundling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,12 +83,21 @@ install(TARGETS ChessGUI
 )
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/assets DESTINATION .)
-install(FILES ${CMAKE_SOURCE_DIR}/lc0.exe DESTINATION .)
 
-# Install OpenCV DLL (adjust filename if needed)
-install(FILES "C:/opencv/build/x64/vc16/bin/opencv_world4110.dll" DESTINATION .)
+# Bundle Lc0 engine
+set(LC0_DIR ${CMAKE_SOURCE_DIR}/external/lc0)
+if(EXISTS "${LC0_DIR}/lc0.exe")
+    install(DIRECTORY ${LC0_DIR}/ DESTINATION lc0)
+else()
+    message(WARNING "Lc0 engine not found: ${LC0_DIR}")
+endif()
 
-# Install all Qt DLLs copied by windeployqt into staging/
+# Bundle Python scripts
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/external/python/
+        DESTINATION python
+        PATTERN "__pycache__" EXCLUDE)
+
+# Install runtime libraries from Qt deployment
 install(DIRECTORY "${CMAKE_BINARY_DIR}/staging/"
         DESTINATION .
         FILES_MATCHING PATTERN "*.dll")
@@ -97,34 +106,18 @@ if(QT_VERSION_MAJOR EQUAL 6)
     qt_finalize_executable(ChessGUI)
 endif()
 
-# Copy python to build output
-add_custom_command(
-    TARGET ${PROJECT_NAME} POST_BUILD
+# Add post-build copy of runtime folders
+add_custom_command(TARGET ChessGUI POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
-            "${CMAKE_SOURCE_DIR}/external/python"
-            "$<TARGET_FILE_DIR:${PROJECT_NAME}>/python"
-    COMMENT "Copying Python folder to build output..."
-)
-
-# Install into package
-# Install Python scripts without preserving the top-level directory
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/external/python/"
-        DESTINATION python
-        PATTERN "__pycache__" EXCLUDE)
-
-
-install(FILES ${CPACK_INSTALL_SYSTEM_RUNTIME_LIBS}
-        DESTINATION python)
-
-file(COPY ${CMAKE_SOURCE_DIR}/lc0.exe DESTINATION ${CMAKE_BINARY_DIR})
-
-# Copy assets folder to build directory
-add_custom_command(
-    TARGET ${PROJECT_NAME} POST_BUILD
+            ${CMAKE_SOURCE_DIR}/assets
+            $<TARGET_FILE_DIR:ChessGUI>/assets
     COMMAND ${CMAKE_COMMAND} -E copy_directory
-            "${CMAKE_SOURCE_DIR}/assets"
-            "$<TARGET_FILE_DIR:${PROJECT_NAME}>/assets"
-    COMMENT "Copying assets folder to build output..."
+            ${LC0_DIR}
+            $<TARGET_FILE_DIR:ChessGUI>/lc0
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_SOURCE_DIR}/external/python
+            $<TARGET_FILE_DIR:ChessGUI>/python
+    COMMENT "Copying runtime folders: assets/, lc0/, python/"
 )
 
 # Find OpenCV - assumes OpenCV_DIR is passed at configure time

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The GUI then:
 * Renders the position in its own board widget  
 * Draws an arrow for Maia’s best move
 * Shows evaluation, move history, and the raw FEN
-* Offers **Stealth Mode** that limits search depth and chooses moves with human-like randomness (optional)
+* Offers **Stealth Mode** with adjustable softmax temperature and optional second-line injection
 * Can **Auto-Move** the chosen move directly on the board (optional)  
 
 Use it for real-time tactics training, stream overlays, or hands-free auto-playing—completely client-side.
@@ -48,9 +48,10 @@ Use it for real-time tactics training, stream overlays, or hands-free auto-playi
 |----------|------------|
 | **Real-time Vision** | CCN predicts an 8 × 8 grid of piece classes from 256 × 256 RGB crops. Currently only works with specific themes. You can train your own weights at  https://github.com/hammersurf221/FENgine|
 | **Maia/Lc0 Integration** | UCI handshake with backend options and evaluation parsing. |
-| **Stealth Mode** | Uses shallow depth (e.g., 6 plies) then picks from the top line via softmax with human delays. |
+| **Engine Strength** | Choose from Maia-1100, 1500, 1900, or unrestricted weights. |
+| **Stealth Mode** | Uses shallow depth then samples by softmax (temperature configurable) with optional 2nd-line injection. |
 | **Auto-Move** | Uses `pyautogui` to click the recommended move on your chess site—works with Lichess/Chess.com & most GUI boards. Toggle on/off any time. |
-| **Telemetry Dashboard** | Records stealth moves to `telemetry_log.json` and shows real-time stats in a dockable widget. |
+| **Telemetry Dashboard** | Records stealth moves to `telemetry_log.json` (rotated at 5 MB; clearable) and shows real-time stats in a dockable widget. |
 | **Region Auto-Detect + Manual Fallback** | Detects the chessboard rectangle via OpenCV; cancel to draw region manually. |
 | **Global Hotkeys** | Toggle analysis, stealth, auto-move, overlays without leaving your game. |
 | **Cross-Platform** | Builds on Windows, macOS, and Linux with Qt 5/6 + CMake; Python 3.8 + runtime bundled or system-wide. |

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -40,6 +40,7 @@ private slots:
     void on_toggleAnalysisButton_clicked();
     void on_resetGameButton_clicked();
     void openSettings();
+    void clearTelemetryLog();
 
 private:
     Ui::MainWindow *ui;
@@ -77,13 +78,16 @@ private:
     void updateEvalLabel();
     QString boardTurnColor;   // "w" or "b"
     QString weightsPath;
+    double stealthTemperature = 0.035;
+    int stealthInjectPct = 10;
+    QString engineStrength = "Unrestricted";
 
     struct MoveCandidate {
         QString move;
         int rank = 1;
         int score = 0;
     };
-    MoveCandidate pickBestMove(bool stealth);
+    MoveCandidate pickBestMove(bool stealth, double temperature, int injectPct);
     SettingsDialog* settingsDialog = nullptr;
     QString currentBestMove;
     void playBestMove();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -374,6 +374,7 @@ border: 1px solid #444;
      <string>Settings</string>
     </property>
     <addaction name="actionOpen_Settings"/>
+    <addaction name="actionClear_Telemetry_Log"/>
    </widget>
    <addaction name="menusettingsTab"/>
   </widget>
@@ -381,6 +382,11 @@ border: 1px solid #444;
   <action name="actionOpen_Settings">
    <property name="text">
     <string>Open Settings...</string>
+   </property>
+  </action>
+  <action name="actionClear_Telemetry_Log">
+   <property name="text">
+    <string>Clear Telemetry Log...</string>
    </property>
   </action>
  </widget>

--- a/settingsdialog.cpp
+++ b/settingsdialog.cpp
@@ -2,6 +2,7 @@
 #include <QTabWidget>
 #include <QCheckBox>
 #include <QSpinBox>
+#include <QDoubleSpinBox>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QComboBox>
@@ -30,6 +31,13 @@ SettingsDialog::SettingsDialog(QWidget *parent)
 
     stealthCheckBox = new QCheckBox(tr("Enable Stealth Mode"), coreTab);
     coreLayout->addRow(stealthCheckBox);
+    temperatureSpinBox = new QDoubleSpinBox(coreTab);
+    temperatureSpinBox->setRange(0.01, 0.10);
+    temperatureSpinBox->setSingleStep(0.005);
+    coreLayout->addRow(tr("Softmax Temperature"), temperatureSpinBox);
+    injectSpinBox = new QSpinBox(coreTab);
+    injectSpinBox->setRange(0, 30);
+    coreLayout->addRow(tr("Inject 2nd Line (%)"), injectSpinBox);
     coreTab->setLayout(coreLayout);
     tabs->addTab(coreTab, tr("Core"));
 
@@ -86,6 +94,10 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     weightsWidget->setLayout(weightsLayout);
     miscLayout->addRow(tr("Maia Weights File (.pb.gz)"), weightsWidget);
 
+    strengthComboBox = new QComboBox(miscTab);
+    strengthComboBox->addItems({tr("Unrestricted"), tr("Maia-1100"), tr("Maia-1500"), tr("Maia-1900")});
+    miscLayout->addRow(tr("Engine Strength"), strengthComboBox);
+
 
     colorComboBox = new QComboBox(miscTab);
     colorComboBox->addItems({tr("White"), tr("Black")});
@@ -137,6 +149,9 @@ void SettingsDialog::loadSettings()
     setAutoMoveWhenReady(settings.value("autoMoveWhenReady", false).toBool());
     setAutoMoveDelay(settings.value("autoMoveDelay", 0).toInt());
 
+    setStealthTemperature(settings.value("stealthTemperature", 0.035).toDouble());
+    setInjectPercent(settings.value("stealthInjectPct", 10).toInt());
+
 
     QString defaultStockfish = QCoreApplication::applicationDirPath() + "/lc0.exe";
     QString defaultFenModel = QCoreApplication::applicationDirPath() + "/python/fen_tracker/ccn_model_default.pth";
@@ -148,6 +163,7 @@ void SettingsDialog::loadSettings()
     setEnginePath(settings.value("enginePath", defaultStockfish).toString());
     setFenModelPath(settings.value("fenModelPath", defaultFenModel).toString());
     setDefaultPlayerColor(settings.value("defaultColor", "White").toString());
+    setEngineStrength(settings.value("engineStrength", "Unrestricted").toString());
 }
 
 void SettingsDialog::saveSettings()
@@ -163,6 +179,9 @@ void SettingsDialog::saveSettings()
     settings.setValue("fenModelPath", fenModelPath());
     settings.setValue("defaultColor", defaultPlayerColor());
     settings.setValue("weightsPath", weightsPathEdit->text());
+    settings.setValue("stealthTemperature", stealthTemperature());
+    settings.setValue("stealthInjectPct", injectPercent());
+    settings.setValue("engineStrength", engineStrength());
 
 }
 
@@ -199,6 +218,9 @@ void SettingsDialog::resetDefaults()
     setFenModelPath(QCoreApplication::applicationDirPath() + "/python/fen_tracker/ccn_model_default.pth");
     setDefaultPlayerColor("White");
     weightsPathEdit->setText(QCoreApplication::applicationDirPath() + "/maia1900.pb.gz");
+    setStealthTemperature(0.035);
+    setInjectPercent(10);
+    setEngineStrength("Unrestricted");
 
 }
 
@@ -305,5 +327,37 @@ void SettingsDialog::setDefaultPlayerColor(const QString &color)
 QString SettingsDialog::defaultPlayerColor() const
 {
     return colorComboBox->currentText();
+}
+
+void SettingsDialog::setStealthTemperature(double temp)
+{
+    temperatureSpinBox->setValue(temp);
+}
+
+double SettingsDialog::stealthTemperature() const
+{
+    return temperatureSpinBox->value();
+}
+
+void SettingsDialog::setInjectPercent(int pct)
+{
+    injectSpinBox->setValue(pct);
+}
+
+int SettingsDialog::injectPercent() const
+{
+    return injectSpinBox->value();
+}
+
+void SettingsDialog::setEngineStrength(const QString &strength)
+{
+    int idx = strengthComboBox->findText(strength);
+    if (idx >= 0)
+        strengthComboBox->setCurrentIndex(idx);
+}
+
+QString SettingsDialog::engineStrength() const
+{
+    return strengthComboBox->currentText();
 }
 

--- a/settingsdialog.h
+++ b/settingsdialog.h
@@ -8,6 +8,7 @@
 class QTabWidget;
 class QCheckBox;
 class QSpinBox;
+class QDoubleSpinBox;
 class QLineEdit;
 class QPushButton;
 class QComboBox;
@@ -28,6 +29,10 @@ public:
     int engineDepth() const;
     void setStealthModeEnabled(bool enabled);
     bool stealthModeEnabled() const;
+    void setStealthTemperature(double temp);
+    double stealthTemperature() const;
+    void setInjectPercent(int pct);
+    int injectPercent() const;
 
     // Board detection
     void setUseAutoBoardDetection(bool use);
@@ -48,6 +53,8 @@ public:
     QString fenModelPath() const;
     void setDefaultPlayerColor(const QString &color);
     QString defaultPlayerColor() const;
+    void setEngineStrength(const QString &strength);
+    QString engineStrength() const;
 
     QString weightsPath() const;
     void setWeightsPath(const QString &path);
@@ -84,6 +91,9 @@ private:
     QLineEdit *fenModelPathEdit;
     QPushButton *fenModelBrowseButton;
     QComboBox *colorComboBox;
+    QDoubleSpinBox *temperatureSpinBox;
+    QSpinBox *injectSpinBox;
+    QComboBox *strengthComboBox;
 
     QPushButton *resetButton;
     QDialogButtonBox *buttonBox;

--- a/telemetrymanager.h
+++ b/telemetrymanager.h
@@ -25,6 +25,7 @@ public:
     ~TelemetryManager();
 
     void logEntry(const TelemetryEntry &entry);
+    void clearLog();
 
     double bestMovePercent() const;
     double averageCpDelta() const;


### PR DESCRIPTION
## Summary
- add softmax temperature, injection %, and engine strength settings
- support rotating telemetry logs and clearing from the menu
- keep eval bar and arrows visible in stealth mode
- fix "Multipv" spelling and load weights based on strength
- bundle lc0 engine/python in CMake and clean up install

## Testing
- `cmake ..` *(fails: Could not find Qt)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc65ed45c83269e18ae7dcc33a30b