### PR TITLE
Fix weights setting and show telemetry

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -40,6 +40,7 @@ MainWindow::MainWindow(QWidget *parent)
     telemetryManager = new TelemetryManager(this);
     telemetryDock = new TelemetryDashboard(this);
     addDockWidget(Qt::RightDockWidgetArea, telemetryDock);
+    telemetryDock->refresh(telemetryManager);
     randomSeed = static_cast<quint32>(QDateTime::currentMSecsSinceEpoch());
     randomGenerator.seed(randomSeed);
     QSettings settings("ChessGUI", "ChessGUI");
@@ -472,7 +473,7 @@ void MainWindow::startEngine() {
 #endif
     QSettings settings("ChessGUI", "ChessGUI");
     weightsPath = settings.value("weightsPath",
-        QCoreApplication::applicationDirPath() + "/maia1900.pb").toString();
+        QCoreApplication::applicationDirPath() + "/maia1900.pb.gz").toString();
     QString strengthSetting = settings.value("engineStrength", "Unrestricted").toString();
     if (strengthSetting != "Unrestricted") {
         QString fname;
@@ -1016,6 +1017,7 @@ void MainWindow::openSettings()
     settingsDialog->setAutoMoveDelay(autoMoveDelayMs);
     settingsDialog->setEnginePath(enginePath);
     settingsDialog->setFenModelPath(fenModelPath);
+    settingsDialog->setWeightsPath(weightsPath);
     settingsDialog->setDefaultPlayerColor(ui->whiteRadioButton->isChecked() ? "White" : "Black");
     settingsDialog->setStealthTemperature(stealthTemperature);
     settingsDialog->setInjectPercent(stealthInjectPct);
@@ -1030,6 +1032,7 @@ void MainWindow::openSettings()
         autoMoveDelayMs = settingsDialog->autoMoveDelay();
         enginePath = settingsDialog->enginePath();
         fenModelPath = settingsDialog->fenModelPath();
+        weightsPath = settingsDialog->weightsPath();
         stealthTemperature = settingsDialog->stealthTemperature();
         stealthInjectPct = settingsDialog->injectPercent();
         engineStrength = settingsDialog->engineStrength();

--- a/settingsdialog.cpp
+++ b/settingsdialog.cpp
@@ -361,3 +361,13 @@ QString SettingsDialog::engineStrength() const
     return strengthComboBox->currentText();
 }
 
+void SettingsDialog::setWeightsPath(const QString &path)
+{
+    weightsPathEdit->setText(path);
+}
+
+QString SettingsDialog::weightsPath() const
+{
+    return weightsPathEdit->text();
+}
+


### PR DESCRIPTION
## Summary
- hook up weights path in settings dialog
- load `.pb.gz` weights by default
- update telemetry dock when the window opens

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_684bdf4b73348326abcf1c32a663bb4a