### PR TITLE
Refactor telemetry update flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use it for real-time tactics training, stream overlays, or hands-free auto-playi
 | **Engine Strength** | Choose from Maia-1100, 1500, 1900, or unrestricted weights. |
 | **Stealth Mode** | Uses shallow depth then samples by softmax (temperature configurable) with optional 2nd-line injection. |
 | **Auto-Move** | Uses `pyautogui` to click the recommended move on your chess site—works with Lichess/Chess.com & most GUI boards. Toggle on/off any time. |
-| **Telemetry Dashboard** | Records stealth moves to `telemetry_log.json` (rotated at 5 MB; clearable) and shows real-time stats in a dockable widget. |
+| **Telemetry Dashboard** | Records stealth moves to `telemetry_log.json` (rotated at 5 MB; clearable) and now updates automatically via signals to show real-time stats in a dockable widget. |
 | **Region Auto-Detect + Manual Fallback** | Detects the chessboard rectangle via OpenCV; cancel to draw region manually. |
 | **Global Hotkeys** | Toggle analysis, stealth, auto-move, overlays without leaving your game. |
 | **Cross-Platform** | Builds on Windows, macOS, and Linux with Qt 5/6 + CMake; Python 3.8 + runtime bundled or system-wide. |

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -40,7 +40,7 @@ MainWindow::MainWindow(QWidget *parent)
     telemetryManager = new TelemetryManager(this);
     telemetryDock = new TelemetryDashboard(this);
     addDockWidget(Qt::RightDockWidgetArea, telemetryDock);
-    telemetryDock->refresh(telemetryManager);
+    telemetryDock->attachManager(telemetryManager);
     randomSeed = static_cast<quint32>(QDateTime::currentMSecsSinceEpoch());
     randomGenerator.seed(randomSeed);
     QSettings settings("ChessGUI", "ChessGUI");
@@ -876,7 +876,6 @@ void MainWindow::playBestMove() {
         pendingTelemetry.thinkTimeMs = delay;
         pendingTelemetry.timestamp = QDateTime::currentDateTime().toString(Qt::ISODate);
         telemetryManager->logEntry(pendingTelemetry);
-        telemetryDock->refresh(telemetryManager);
         pendingTelemetry = TelemetryEntry();
     }
 
@@ -1173,6 +1172,4 @@ void MainWindow::clearTelemetryLog()
 {
     if (telemetryManager)
         telemetryManager->clearLog();
-    if (telemetryDock)
-        telemetryDock->refresh(telemetryManager);
 }

--- a/telemetrydashboard.cpp
+++ b/telemetrydashboard.cpp
@@ -37,7 +37,31 @@ TelemetryDashboard::TelemetryDashboard(QWidget *parent)
     setWindowTitle("Telemetry");
 }
 
-void TelemetryDashboard::refresh(TelemetryManager *manager)
+void TelemetryDashboard::attachManager(TelemetryManager *m)
+{
+    if (manager)
+        disconnect(manager, nullptr, this, nullptr);
+    manager = m;
+    if (manager) {
+        connect(manager, &TelemetryManager::entryLogged,
+                this, &TelemetryDashboard::onEntryLogged);
+        connect(manager, &TelemetryManager::logCleared,
+                this, &TelemetryDashboard::onLogCleared);
+        refresh();
+    }
+}
+
+void TelemetryDashboard::onEntryLogged(const TelemetryEntry &)
+{
+    refresh();
+}
+
+void TelemetryDashboard::onLogCleared()
+{
+    refresh();
+}
+
+void TelemetryDashboard::refresh()
 {
     if (!manager)
         return;

--- a/telemetrydashboard.h
+++ b/telemetrydashboard.h
@@ -12,9 +12,16 @@ class TelemetryDashboard : public QDockWidget {
 public:
     explicit TelemetryDashboard(QWidget *parent = nullptr);
 
-    void refresh(TelemetryManager *manager);
+    void attachManager(TelemetryManager *manager);
+
+private slots:
+    void onEntryLogged(const TelemetryEntry &entry);
+    void onLogCleared();
 
 private:
+    void refresh();
+
+    TelemetryManager *manager = nullptr;
     QLabel *bestMoveLabel;
     QLabel *avgDeltaLabel;
     QTableWidget *rankTable;

--- a/telemetrymanager.cpp
+++ b/telemetrymanager.cpp
@@ -38,8 +38,10 @@ TelemetryManager::~TelemetryManager() {
 
 void TelemetryManager::logEntry(const TelemetryEntry &entry) {
     entries.append(entry);
-    if (!logFile.isOpen())
+    if (!logFile.isOpen()) {
+        emit entryLogged(entry);
         return;
+    }
 
     if (!firstEntry)
         logFile.write(",\n");
@@ -58,6 +60,8 @@ void TelemetryManager::logEntry(const TelemetryEntry &entry) {
     QJsonDocument doc(obj);
     logFile.write(doc.toJson(QJsonDocument::Compact));
     logFile.flush();
+
+    emit entryLogged(entry);
 }
 
 void TelemetryManager::clearLog() {
@@ -71,6 +75,8 @@ void TelemetryManager::clearLog() {
         logFile.write("[");
         logFile.flush();
     }
+
+    emit logCleared();
 }
 
 double TelemetryManager::bestMovePercent() const {

--- a/telemetrymanager.h
+++ b/telemetrymanager.h
@@ -32,6 +32,10 @@ public:
     QMap<int,int> rankCounts() const;
     QList<int> recentThinkTimes(int max = 10) const;
 
+signals:
+    void entryLogged(const TelemetryEntry &entry);
+    void logCleared();
+
 private:
     QFile logFile;
     QVector<TelemetryEntry> entries;


### PR DESCRIPTION
## Summary
- connect the dashboard directly to the manager via Qt signals
- emit signals when telemetry is logged or cleared
- update README to mention automatic dashboard updates

## Testing
- `ctest` *(fails: No test configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684bea5ef9248326932ba86ebaa2eed3