### PR TITLE
Rewrite telemetry dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use it for real-time tactics training, stream overlays, or hands-free auto-playi
 | **Engine Strength** | Choose from Maia-1100, 1500, 1900, or unrestricted weights. |
 | **Stealth Mode** | Uses shallow depth then samples by softmax (temperature configurable) with optional 2nd-line injection. |
 | **Auto-Move** | Uses `pyautogui` to click the recommended move on your chess site—works with Lichess/Chess.com & most GUI boards. Toggle on/off any time. |
-| **Telemetry Dashboard** | Records stealth moves to `telemetry_log.json` (rotated at 5 MB; clearable) and now updates automatically via signals to show real-time stats in a dockable widget. |
+| **Telemetry Dashboard** | Redesigned dock widget showing a live table of recorded moves with summary statistics, all backed by `telemetry_log.json` (rotated at 5&nbsp;MB). |
 | **Region Auto-Detect + Manual Fallback** | Detects the chessboard rectangle via OpenCV; cancel to draw region manually. |
 | **Global Hotkeys** | Toggle analysis, stealth, auto-move, overlays without leaving your game. |
 | **Cross-Platform** | Builds on Windows, macOS, and Linux with Qt 5/6 + CMake; Python 3.8 + runtime bundled or system-wide. |

--- a/telemetrydashboard.h
+++ b/telemetrydashboard.h
@@ -4,7 +4,6 @@
 #include <QDockWidget>
 #include <QLabel>
 #include <QTableWidget>
-#include <QProgressBar>
 #include "telemetrymanager.h"
 
 class TelemetryDashboard : public QDockWidget {
@@ -19,13 +18,12 @@ private slots:
     void onLogCleared();
 
 private:
-    void refresh();
+    void addEntry(const TelemetryEntry &entry);
+    void updateSummary();
 
     TelemetryManager *manager = nullptr;
-    QLabel *bestMoveLabel;
-    QLabel *avgDeltaLabel;
-    QTableWidget *rankTable;
-    QList<QProgressBar*> thinkBars;
+    QLabel *summaryLabel;
+    QTableWidget *entryTable;
 };
 
 #endif // TELEMETRYDASHBOARD_H


### PR DESCRIPTION
## Summary
- redesign the telemetry dashboard widget
- display a table of logged moves with summary stats
- update README description of telemetry dashboard

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT" )*

------
https://chatgpt.com/codex/tasks/task_e_684bf04207b08326ad28c221b5a2db4e