### PR TITLE
Implement TelemetryDashboardV2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ set(PROJECT_SOURCES
         chessboard_detector.cpp
         globalhotkeymanager.h
         globalhotkeymanager.cpp
+        telemetrymanager.h
+        telemetrymanager.cpp
+        telemetrydashboardv2.h
+        telemetrydashboardv2.cpp
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Use it for real-time tactics training, stream overlays, or hands-free auto-playi
 | **Engine Strength** | Choose from Maia-1100, 1500, 1900, or unrestricted weights. |
 | **Stealth Mode** | Uses shallow depth then samples by softmax (temperature configurable) with optional 2nd-line injection. |
 | **Auto-Move** | Uses `pyautogui` to click the recommended move on your chess site—works with Lichess/Chess.com & most GUI boards. Toggle on/off any time. |
+| **Telemetry Dashboard** | Records stealth moves to `telemetry_log.json` (rotated at 5 MB; clearable) and displays real-time stats in a dockable widget. |
 | **Region Auto-Detect + Manual Fallback** | Detects the chessboard rectangle via OpenCV; cancel to draw region manually. |
 | **Global Hotkeys** | Toggle analysis, stealth, auto-move, overlays without leaving your game. |
 | **Cross-Platform** | Builds on Windows, macOS, and Linux with Qt 5/6 + CMake; Python 3.8 + runtime bundled or system-wide. |

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -17,6 +17,8 @@
 #include <QRandomGenerator>
 #include <QDateTime>
 #include "globalhotkeymanager.h"
+#include "telemetrymanager.h"
+#include "telemetrydashboardv2.h"
 
 
 QT_BEGIN_NAMESPACE
@@ -38,6 +40,7 @@ private slots:
     void on_toggleAnalysisButton_clicked();
     void on_resetGameButton_clicked();
     void openSettings();
+    void clearTelemetryLog();
 
 private:
     Ui::MainWindow *ui;
@@ -106,6 +109,10 @@ private:
     quint32 randomSeed = 0;
     QRandomGenerator randomGenerator;
     GlobalHotkeyManager* hotkeyManager = nullptr;
+
+    TelemetryManager* telemetryManager = nullptr;
+    TelemetryDashboardV2* telemetryDock = nullptr;
+    TelemetryEntry pendingTelemetry;
 
 
     QStringList moveHistoryLines;

--- a/telemetrydashboardv2.cpp
+++ b/telemetrydashboardv2.cpp
@@ -1,0 +1,74 @@
+#include "telemetrydashboardv2.h"
+#include <QLabel>
+#include <QTableWidget>
+#include <QHeaderView>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QMap>
+#include <QVector>
+#include <QVBoxLayout>
+#include <QWidget>
+
+TelemetryDashboardV2::TelemetryDashboardV2(QWidget *parent)
+    : QDockWidget(parent)
+{
+    QWidget *container = new QWidget(this);
+    QVBoxLayout *layout = new QVBoxLayout(container);
+
+    bestMoveLabel = new QLabel(tr("Best Move %: N/A"), container);
+    averageCpLabel = new QLabel(tr("Average cpDelta: N/A"), container);
+
+    rankTable = new QTableWidget(0, 2, container);
+    QStringList headers;
+    headers << tr("Rank") << tr("Count");
+    rankTable->setHorizontalHeaderLabels(headers);
+    rankTable->horizontalHeader()->setStretchLastSection(true);
+    rankTable->verticalHeader()->setVisible(false);
+
+    for (int i = 0; i < 5; ++i) {
+        QProgressBar *bar = new QProgressBar(container);
+        bar->setRange(0, 100);
+        thinkBars.append(bar);
+    }
+
+    clearButton = new QPushButton(tr("Clear Telemetry"), container);
+
+    layout->addWidget(bestMoveLabel);
+    layout->addWidget(averageCpLabel);
+    layout->addWidget(rankTable);
+    for (QProgressBar *bar : thinkBars)
+        layout->addWidget(bar);
+    layout->addStretch();
+    layout->addWidget(clearButton);
+
+    container->setLayout(layout);
+    setWidget(container);
+
+    connect(clearButton, &QPushButton::clicked,
+            this, &TelemetryDashboardV2::clearTelemetryRequested);
+}
+
+void TelemetryDashboardV2::refresh(TelemetryManager *manager)
+{
+    if (!manager)
+        return;
+
+    bestMoveLabel->setText(tr("Best Move %: %1")
+                           .arg(manager->bestMovePercent(), 0, 'f', 1));
+    averageCpLabel->setText(tr("Average cpDelta: %1")
+                            .arg(manager->averageCpDelta(), 0, 'f', 1));
+
+    QMap<int, int> counts = manager->rankCounts();
+    rankTable->setRowCount(counts.size());
+    int row = 0;
+    for (auto it = counts.cbegin(); it != counts.cend(); ++it, ++row) {
+        rankTable->setItem(row, 0,
+                           new QTableWidgetItem(QString::number(it.key())));
+        rankTable->setItem(row, 1,
+                           new QTableWidgetItem(QString::number(it.value())));
+    }
+
+    QVector<int> times = manager->recentThinkTimes(thinkBars.size());
+    for (int i = 0; i < thinkBars.size() && i < times.size(); ++i)
+        thinkBars[i]->setValue(times[i]);
+}

--- a/telemetrydashboardv2.h
+++ b/telemetrydashboardv2.h
@@ -1,0 +1,32 @@
+#ifndef TELEMETRYDASHBOARDV2_H
+#define TELEMETRYDASHBOARDV2_H
+
+#include <QDockWidget>
+#include <QList>
+
+class QLabel;
+class QTableWidget;
+class QProgressBar;
+class QPushButton;
+class TelemetryManager;
+
+class TelemetryDashboardV2 : public QDockWidget
+{
+    Q_OBJECT
+public:
+    explicit TelemetryDashboardV2(QWidget *parent = nullptr);
+
+    void refresh(TelemetryManager *manager);
+
+signals:
+    void clearTelemetryRequested();
+
+private:
+    QLabel *bestMoveLabel;
+    QLabel *averageCpLabel;
+    QTableWidget *rankTable;
+    QList<QProgressBar *> thinkBars;
+    QPushButton *clearButton;
+};
+
+#endif // TELEMETRYDASHBOARDV2_H

--- a/telemetrymanager.cpp
+++ b/telemetrymanager.cpp
@@ -1,0 +1,121 @@
+#include "telemetrymanager.h"
+#include <QCoreApplication>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QDateTime>
+#include <QDate>
+#include <QFileInfo>
+#include <QDir>
+#include <QStandardPaths>
+
+TelemetryManager::TelemetryManager(QObject *parent)
+    : QObject(parent),
+    firstEntry(true)
+{
+    QString path = QCoreApplication::applicationDirPath() + "/telemetry_log.json";
+    QFileInfo info(path);
+    if (info.exists() && info.size() > 5 * 1024 * 1024) {
+        QString rotated = QCoreApplication::applicationDirPath() +
+                          "/telemetry_log_" + QDate::currentDate().toString("yyyyMMdd") + ".json";
+        QFile::rename(path, rotated);
+    }
+
+    logFile.setFileName(path);
+    if (logFile.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+        logFile.write("[");
+        logFile.flush();
+    }
+}
+
+TelemetryManager::~TelemetryManager()
+{
+    if (logFile.isOpen()) {
+        logFile.write("\n]\n");
+        logFile.close();
+    }
+}
+
+void TelemetryManager::logEntry(const TelemetryEntry &entry)
+{
+    entries.append(entry);
+    if (!logFile.isOpen()) {
+        emit entryLogged(entry);
+        return;
+    }
+
+    if (!firstEntry)
+        logFile.write(",\n");
+    firstEntry = false;
+
+    QJsonObject obj;
+    obj["timestamp"] = entry.timestamp;
+    obj["fen"] = entry.fen;
+    obj["move"] = entry.move;
+    obj["rank"] = entry.rank;
+    obj["evalPlayed"] = entry.evalPlayed;
+    obj["evalBest"] = entry.evalBest;
+    obj["cpDelta"] = entry.cpDelta;
+    obj["thinkTimeMs"] = entry.thinkTimeMs;
+
+    QJsonDocument doc(obj);
+    logFile.write(doc.toJson(QJsonDocument::Compact));
+    logFile.flush();
+
+    emit entryLogged(entry);
+}
+
+void TelemetryManager::clearLog()
+{
+    if (logFile.isOpen()) {
+        logFile.close();
+    }
+    QFile::remove(logFile.fileName());
+    entries.clear();
+    firstEntry = true;
+    if (logFile.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+        logFile.write("[");
+        logFile.flush();
+    }
+
+    emit logCleared();
+}
+
+double TelemetryManager::bestMovePercent() const
+{
+    if (entries.isEmpty())
+        return 0.0;
+    int best = 0;
+    for (const TelemetryEntry &e : entries) {
+        if (e.rank == 1)
+            ++best;
+    }
+    return 100.0 * best / entries.size();
+}
+
+double TelemetryManager::averageCpDelta() const
+{
+    if (entries.isEmpty())
+        return 0.0;
+    long long sum = 0;
+    for (const TelemetryEntry &e : entries)
+        sum += e.cpDelta;
+    return double(sum) / entries.size();
+}
+
+QMap<int,int> TelemetryManager::rankCounts() const
+{
+    QMap<int,int> counts;
+    for (const TelemetryEntry &e : entries)
+        counts[e.rank] = counts.value(e.rank,0) + 1;
+    return counts;
+}
+
+QList<int> TelemetryManager::recentThinkTimes(int max) const
+{
+    QList<int> times;
+    int start = qMax(0, entries.size() - max);
+    for (int i=start; i<entries.size(); ++i)
+        times.append(entries[i].thinkTimeMs);
+    return times;
+}
+

--- a/telemetrymanager.h
+++ b/telemetrymanager.h
@@ -1,0 +1,46 @@
+#ifndef TELEMETRYMANAGER_H
+#define TELEMETRYMANAGER_H
+
+#include <QObject>
+#include <QFile>
+#include <QVector>
+#include <QMap>
+#include <QJsonObject>
+
+struct TelemetryEntry {
+    QString timestamp;
+    QString fen;
+    QString move;
+    int rank = 0;
+    int evalPlayed = 0;
+    int evalBest = 0;
+    int cpDelta = 0;
+    int thinkTimeMs = 0;
+};
+
+class TelemetryManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit TelemetryManager(QObject *parent = nullptr);
+    ~TelemetryManager();
+
+    void logEntry(const TelemetryEntry &entry);
+    void clearLog();
+
+    double bestMovePercent() const;
+    double averageCpDelta() const;
+    QMap<int,int> rankCounts() const;
+    QList<int> recentThinkTimes(int max = 10) const;
+
+signals:
+    void entryLogged(const TelemetryEntry &entry);
+    void logCleared();
+
+private:
+    QFile logFile;
+    QVector<TelemetryEntry> entries;
+    bool firstEntry = true;
+};
+
+#endif // TELEMETRYMANAGER_H


### PR DESCRIPTION
## Summary
- add TelemetryManager class for logging and stats
- implement TelemetryDashboardV2 widget with clear telemetry button
- integrate telemetry dock and manager into MainWindow
- document telemetry dashboard in README

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*


------
https://chatgpt.com/codex/tasks/task_e_684c6724dd3483268925fb99c84be1a0