### PR TITLE
Add human-likeness telemetry based on policy probability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Svg)
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core Widgets Graphs)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets Svg Graphs)
 
 set(PROJECT_SOURCES
         main.cpp
@@ -59,7 +58,7 @@ else()
     endif()
 endif()
 
-target_link_libraries(ChessGUI PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Svg)
+target_link_libraries(ChessGUI PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Svg Qt${QT_VERSION_MAJOR}::Graphs)
 
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -498,6 +498,10 @@ void MainWindow::startEngine() {
         QRegularExpression cpPattern("score cp (-?\\d+)");
         QRegularExpression pvPattern(
             "multipv\\s+(\\d+)\\s+.*score\\s+cp\\s+(-?\\d+)\\s+.*pv\\s+([a-h][1-8][a-h][1-8])");
+        QRegularExpression policyPattern1(
+            "info string\\s+([a-h][1-8][a-h][1-8]).*\\(P:\\s*([0-9.]+)%\\)");
+        QRegularExpression policyPattern2(
+            "info move\\s+([a-h][1-8][a-h][1-8]).*policy\\s+([0-9.]+)");
 
         for (const QString& line : lines) {
             QString trimmed = line.trimmed();
@@ -508,6 +512,22 @@ void MainWindow::startEngine() {
                 int cp = pvMatch.captured(2).toInt();
                 QString mv = pvMatch.captured(3);
                 multipvMoves[idx] = qMakePair(mv, cp);
+            }
+
+            QRegularExpressionMatch pol1 = policyPattern1.match(trimmed);
+            if (pol1.hasMatch()) {
+                QString mv = pol1.captured(1);
+                double prob = pol1.captured(2).toDouble() / 100.0;
+                policyProbMap[mv] = prob;
+            } else {
+                QRegularExpressionMatch pol2 = policyPattern2.match(trimmed);
+                if (pol2.hasMatch()) {
+                    QString mv = pol2.captured(1);
+                    double prob = pol2.captured(2).toDouble();
+                    if (prob > 1.0)
+                        prob /= 100.0;
+                    policyProbMap[mv] = prob;
+                }
             }
 
             QRegularExpressionMatch bestMoveMatch = bestMovePattern.match(trimmed);
@@ -751,6 +771,7 @@ void MainWindow::evaluatePosition(const QString& fen) {
     }
 
     multipvMoves.clear();
+    policyProbMap.clear();
     selectedBestMoveRank = 1;
 
     for (const QString& cmd : commands) {
@@ -1155,10 +1176,7 @@ MainWindow::MoveCandidate MainWindow::pickBestMove(bool stealth, double temperat
 
     pendingTelemetry.fen = lastEvaluatedFen;
     pendingTelemetry.move = choice.move;
-    pendingTelemetry.rank = choice.rank;
-    pendingTelemetry.evalPlayed = choice.score;
-    pendingTelemetry.evalBest = bestScore;
-    pendingTelemetry.cpDelta = bestScore - choice.score;
+    pendingTelemetry.policyProb = policyProbMap.value(choice.move, 0.0);
     pendingTelemetry.thinkTimeMs = 0;
 
     if (candidates.size() >= 2 && bestScore - candidates[1].score <= 60) {

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -101,6 +101,7 @@ private:
     QHash<QString, int> repetitionTable;
     bool automoveInProgress = false;
     QMap<int, QPair<QString, int>> multipvMoves;
+    QMap<QString, double> policyProbMap;
     int selectedBestMoveRank = 1;
     double accuracy = 0.9;
     QElapsedTimer screenshotElapsed;

--- a/telemetrydashboardv2.h
+++ b/telemetrydashboardv2.h
@@ -4,9 +4,15 @@
 #include <QDockWidget>
 #include <QList>
 
+namespace QtGraphs {
+class QChartView;
+class QBarSeries;
+class QBarSet;
+class QBarCategoryAxis;
+class QValueAxis;
+}
+
 class QLabel;
-class QTableWidget;
-class QProgressBar;
 class QPushButton;
 class TelemetryManager;
 
@@ -22,10 +28,11 @@ signals:
     void clearTelemetryRequested();
 
 private:
-    QLabel *bestMoveLabel;
-    QLabel *averageCpLabel;
-    QTableWidget *rankTable;
-    QList<QProgressBar *> thinkBars;
+    QLabel *averageLabel;
+    QtGraphs::QChartView *chartView;
+    QtGraphs::QBarSeries *series;
+    QtGraphs::QBarSet *barSet;
+    QtGraphs::QValueAxis *axisY;
     QPushButton *clearButton;
 };
 

--- a/telemetrymanager.h
+++ b/telemetrymanager.h
@@ -11,10 +11,7 @@ struct TelemetryEntry {
     QString timestamp;
     QString fen;
     QString move;
-    int rank = 0;
-    int evalPlayed = 0;
-    int evalBest = 0;
-    int cpDelta = 0;
+    double policyProb = 0.0; // [0,1]
     int thinkTimeMs = 0;
 };
 
@@ -28,10 +25,8 @@ public:
     void logEntry(const TelemetryEntry &entry);
     void clearLog();
 
-    double bestMovePercent() const;
-    double averageCpDelta() const;
-    QMap<int,int> rankCounts() const;
-    QList<int> recentThinkTimes(int max = 10) const;
+    double averagePolicyProb() const; // average over [0,1]
+    QVector<int> policyHistogram() const; // 5 bins
 
 signals:
     void entryLogged(const TelemetryEntry &entry);


### PR DESCRIPTION
## Summary
- track policy probability from Lc0 in `TelemetryEntry`
- compute average policy probability and histogram in `TelemetryManager`
- visualize human-likeness with Qt Graphs in `TelemetryDashboardV2`
- parse policy values from engine output and log them when moves are played
- link Qt Graphs via CMake

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_684d05b23afc8326ad85a4bf611321c4