### PR TITLE
Switch to QtCharts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core Widgets Graphs)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets Svg Graphs)
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core Widgets Charts)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets Svg Charts)
 
 set(PROJECT_SOURCES
         main.cpp
@@ -58,7 +58,7 @@ else()
     endif()
 endif()
 
-target_link_libraries(ChessGUI PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Svg Qt${QT_VERSION_MAJOR}::Graphs)
+target_link_libraries(ChessGUI PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Svg Qt${QT_VERSION_MAJOR}::Charts)
 
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Use it for real-time tactics training, stream overlays, or hands-free auto-playi
 | Component | Minimum Version |
 |-----------|-----------------|
 | **Lc0** | 0.29 + |
-| **Qt** (Widgets, GUI, Core) | 5.15 or 6.x |
+| **Qt** (Widgets, GUI, Core, Charts) | 5.15 or 6.x |
 | **OpenCV** | 4.x |
 | **Python** | 3.8 + |
 | Python libs | `torch >= 2.0`, `torchvision`, `numpy`, `Pillow`, `scikit-image`, `pyautogui` |
@@ -152,7 +152,7 @@ Currently placeholders.
 ## Learning Resources
 * **CCN architecture** – see <https://github.com/hammersurf221/FENgine> for model code and residual enhancements.    
 * **Lc0 UCI options** – <https://github.com/LeelaChessZero/lc0/wiki/Parameters>
-* **Qt Widgets** – <https://doc.qt.io/>  
+* **Qt Widgets/Charts** – <https://doc.qt.io/>
 * **OpenCV 4.x tutorials** – <https://docs.opencv.org/>  
 
 ---

--- a/telemetrydashboardv2.cpp
+++ b/telemetrydashboardv2.cpp
@@ -3,12 +3,12 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 #include <QWidget>
-#include <QtGraphs/qchartview.h>
-#include <QtGraphs/qchart.h>
-#include <QtGraphs/qbarset.h>
-#include <QtGraphs/qbarseries.h>
-#include <QtGraphs/qbarcategoryaxis.h>
-#include <QtGraphs/qvalueaxis.h>
+#include <QtCharts/QChartView>
+#include <QtCharts/QChart>
+#include <QtCharts/QBarSet>
+#include <QtCharts/QBarSeries>
+#include <QtCharts/QBarCategoryAxis>
+#include <QtCharts/QValueAxis>
 #include "telemetrymanager.h"
 
 TelemetryDashboardV2::TelemetryDashboardV2(QWidget *parent)
@@ -19,25 +19,25 @@ TelemetryDashboardV2::TelemetryDashboardV2(QWidget *parent)
 
     averageLabel = new QLabel(tr("Average Human-likeness: N/A"), container);
 
-    barSet = new QtGraphs::QBarSet(tr("Moves"));
-    series = new QtGraphs::QBarSeries();
+    barSet = new QtCharts::QBarSet(tr("Moves"));
+    series = new QtCharts::QBarSeries();
     series->append(barSet);
 
     QStringList categories;
     categories << "<0.2" << "0.2–0.4" << "0.4–0.6" << "0.6–0.8" << ">=0.8";
-    QtGraphs::QBarCategoryAxis *axisX = new QtGraphs::QBarCategoryAxis();
+    QtCharts::QBarCategoryAxis *axisX = new QtCharts::QBarCategoryAxis();
     axisX->append(categories);
-    axisY = new QtGraphs::QValueAxis();
+    axisY = new QtCharts::QValueAxis();
     axisY->setRange(0, 1);
 
-    QtGraphs::QChart *chart = new QtGraphs::QChart();
+    QtCharts::QChart *chart = new QtCharts::QChart();
     chart->addSeries(series);
     chart->addAxis(axisX, Qt::AlignBottom);
     chart->addAxis(axisY, Qt::AlignLeft);
     series->attachAxis(axisX);
     series->attachAxis(axisY);
 
-    chartView = new QtGraphs::QChartView(chart, container);
+    chartView = new QtCharts::QChartView(chart, container);
     chartView->setRenderHint(QPainter::Antialiasing);
 
     clearButton = new QPushButton(tr("Clear Telemetry"), container);

--- a/telemetrydashboardv2.h
+++ b/telemetrydashboardv2.h
@@ -4,7 +4,7 @@
 #include <QDockWidget>
 #include <QList>
 
-namespace QtGraphs {
+namespace QtCharts {
 class QChartView;
 class QBarSeries;
 class QBarSet;
@@ -29,10 +29,10 @@ signals:
 
 private:
     QLabel *averageLabel;
-    QtGraphs::QChartView *chartView;
-    QtGraphs::QBarSeries *series;
-    QtGraphs::QBarSet *barSet;
-    QtGraphs::QValueAxis *axisY;
+    QtCharts::QChartView *chartView;
+    QtCharts::QBarSeries *series;
+    QtCharts::QBarSet *barSet;
+    QtCharts::QValueAxis *axisY;
     QPushButton *clearButton;
 };
 


### PR DESCRIPTION
## Summary
- update CMakeLists to use QtCharts instead of QtGraphs
- replace QtGraphs API usage with QtCharts in telemetry dashboard
- update README to list Qt Charts in requirements and resources

## Testing
- `cmake ..` *(fails: Could not find Qt)*

------
https://chatgpt.com/codex/tasks/task_e_684d1335507c8326afd6e5b64db540ce