### PR TITLE
Replace QtCharts with simple progress bar histogram

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core Widgets Charts)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets Svg Charts)
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets Svg)
 
 set(PROJECT_SOURCES
         main.cpp
@@ -58,7 +58,7 @@ else()
     endif()
 endif()
 
-target_link_libraries(ChessGUI PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Svg Qt${QT_VERSION_MAJOR}::Charts)
+target_link_libraries(ChessGUI PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Svg)
 
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Use it for real-time tactics training, stream overlays, or hands-free auto-playi
 | Component | Minimum Version |
 |-----------|-----------------|
 | **Lc0** | 0.29 + |
-| **Qt** (Widgets, GUI, Core, Charts) | 5.15 or 6.x |
+| **Qt** (Widgets, GUI, Core) | 5.15 or 6.x |
 | **OpenCV** | 4.x |
 | **Python** | 3.8 + |
 | Python libs | `torch >= 2.0`, `torchvision`, `numpy`, `Pillow`, `scikit-image`, `pyautogui` |
@@ -152,7 +152,7 @@ Currently placeholders.
 ## Learning Resources
 * **CCN architecture** – see <https://github.com/hammersurf221/FENgine> for model code and residual enhancements.    
 * **Lc0 UCI options** – <https://github.com/LeelaChessZero/lc0/wiki/Parameters>
-* **Qt Widgets/Charts** – <https://doc.qt.io/>
+* **Qt Widgets** – <https://doc.qt.io/>
 * **OpenCV 4.x tutorials** – <https://docs.opencv.org/>  
 
 ---

--- a/telemetrydashboardv2.h
+++ b/telemetrydashboardv2.h
@@ -2,12 +2,8 @@
 #define TELEMETRYDASHBOARDV2_H
 
 #include <QDockWidget>
-#include <QList>
-#include <QtCharts/QChartView>
-#include <QtCharts/QBarSeries>
-#include <QtCharts/QBarSet>
-#include <QtCharts/QBarCategoryAxis>
-#include <QtCharts/QValueAxis>
+#include <QVector>
+#include <QProgressBar>
 
 
 class QLabel;
@@ -27,10 +23,7 @@ signals:
 
 private:
     QLabel *averageLabel;
-    QtCharts::QChartView *chartView;
-    QtCharts::QBarSeries *series;
-    QtCharts::QBarSet *barSet;
-    QtCharts::QValueAxis *axisY;
+    QVector<QProgressBar*> bars;
     QPushButton *clearButton;
 };
 


### PR DESCRIPTION
## Summary
- drop Qt Charts dependency
- implement telemetry histogram with QProgressBars
- update build config for Charts removal
- document new Qt requirements without Charts

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_684d1b858f4c8326adab45eb9072c0aa