### PR TITLE
Fix MoveCandidate and remove unused variables

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -896,12 +896,6 @@ void MainWindow::playBestMove() {
          << (flipped ? "true" : "false")
          << (stealth ? "true" : "false");
 
-    if (stealth) {
-        args << "--phase" << currentPhase
-             << "--complexity" << QString::number(moveComplexity)
-             << "--eval" << QString::number(evalCp / 100.0, 'f', 2);
-    }
-
     qDebug() << "[play_move] args:" << args;
 
     auto execute = [=]() {
@@ -1152,7 +1146,7 @@ void MainWindow::on_resetGameButton_clicked()
     statusBar()->showMessage("Game reset");
 }
 
-MainWindow::MoveCandidate MainWindow::pickBestMove(bool stealth, double temperature, int injectPct)
+MoveCandidate MainWindow::pickBestMove(bool stealth, double temperature, int injectPct)
 {
     MoveCandidate result;
     pendingTelemetry = TelemetryEntry();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -19,6 +19,7 @@
 #include "globalhotkeymanager.h"
 #include "telemetrymanager.h"
 #include "telemetrydashboardv2.h"
+#include "stealthmoveselector.h"
 
 
 QT_BEGIN_NAMESPACE
@@ -82,11 +83,6 @@ private:
     int stealthInjectPct = 10;
     QString engineStrength = "Unrestricted";
 
-    struct MoveCandidate {
-        QString move;
-        int rank = 1;
-        int score = 0;
-    };
     MoveCandidate pickBestMove(bool stealth, double temperature, int injectPct);
     SettingsDialog* settingsDialog = nullptr;
     QString currentBestMove;


### PR DESCRIPTION
## Summary
- include `stealthmoveselector.h` in `mainwindow.h`
- remove duplicate `MoveCandidate` struct from `MainWindow`
- update `pickBestMove` definition to use global `MoveCandidate`
- remove unused arguments when launching `play_move.py`

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_6850f0cf4b9c8326a2c50b7aaab6cac5