### PR TITLE
Add game context parameters to play_move call

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -608,6 +608,9 @@ void MainWindow::startEngine() {
                     }
                 }
 
+                lastBestScore = bestCp;
+                lastMoveComplexity = computeMoveComplexity(mvList);
+
                 StealthMoveSelector selector;
                 selector.setStealthParams(stealthTemperature, 100);
                 selector.setTargetACPL(60.0);
@@ -906,6 +909,11 @@ void MainWindow::playBestMove() {
     bool flipped = (getMyColor() == "b");
     bool stealth = ui->stealthCheck->isChecked();
 
+    QString phase = determinePhaseFromFEN(lastFen);
+    double evalScore = lastBestScore;
+    if (std::abs(evalScore) <= 1.5)
+        evalScore *= 100.0;
+
     QStringList args;
     args << scriptPath
          << from
@@ -914,7 +922,10 @@ void MainWindow::playBestMove() {
          << QString::number(originY)
          << QString::number(tileSize)
          << (flipped ? "true" : "false")
-         << (stealth ? "true" : "false");
+         << (stealth ? "true" : "false")
+         << "--phase" << phase
+         << "--complexity" << QString::number(lastMoveComplexity)
+         << "--eval" << QString::number(evalScore);
 
     qDebug() << "[play_move] args:" << args;
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -103,6 +103,8 @@ private:
     QElapsedTimer screenshotElapsed;
     QElapsedTimer fenElapsed;
     QElapsedTimer evalElapsed;
+    int lastBestScore = 0;
+    int lastMoveComplexity = 0;
     quint32 randomSeed = 0;
     QRandomGenerator randomGenerator;
     GlobalHotkeyManager* hotkeyManager = nullptr;


### PR DESCRIPTION
## Summary
- determine game phase from FEN and compute move complexity
- store best score and complexity from engine multipv output
- send phase, complexity and eval to `play_move.py`

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_6850f3ec18008326ad8264474ea93d06