### PR TITLE
Fix double automove execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ build\Release\FENgineLive.exe  # Windows
 4. The app captures a screenshot every *N ms* (set in **Settings → Analysis Interval**), predicts the FEN, and queries Maia via Lc0.
 5. Watch the best-move arrow, evaluation bar, and PGN history update in real-time.  
 6. Toggle **Stealth Mode** (*`Ctrl + S`*) to enable the humanized move picker.
-7. Toggle **Auto-Move** (*`Ctrl + M`*) if you’d like the app to physically play the move on your board.  
+7. Toggle **Auto-Move** (*`Ctrl + M`*) if you’d like the app to physically play the move on your board. The GUI waits for each move to finish before analyzing again.
 8. Use **Reset Game** when starting a new game.
 
 ---

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -48,7 +48,7 @@ private:
     QRect captureRegion;
     QTimer* screenshotTimer;
     bool analysisRunning = false;
-    QProcess* pythonProcess = nullptr;
+    QProcess* moveProcess = nullptr;
     QProcess* engineProcess = nullptr;
     QString lastFen;
     int analysisInterval = 1000;  // milliseconds


### PR DESCRIPTION
## Summary
- ensure automove process finishes before next move
- wait for active move to end during game reset
- document automove wait behavior in README

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_685104eb1c4c8326a9ff47b870401449