### PR TITLE
Fix SABLE copy step in Windows build

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -53,6 +53,12 @@ if exist "..\external\python\fen_tracker" (
     xcopy "..\external\python\fen_tracker\*" "python\" /Y /Q
 )
 
+if exist "..\external\python\sable" (
+    if not exist "python" mkdir python
+    if not exist "python\sable" mkdir python\sable
+    xcopy "..\external\python\sable\*" "python\sable\" /Y /Q
+)
+
 if exist "..\assets" (
     if not exist "assets" mkdir assets
     xcopy "..\assets\*" "assets\" /Y /Q /E


### PR DESCRIPTION
## Summary
- include external\python\sable files when running `build.bat`

## Testing
- `ctest --output-on-failure`
- `python -m pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_685c931ef948832698da3abf3912704a